### PR TITLE
Fix name of WLANSVC Service

### DIFF
--- a/windows-iot/iot-enterprise/Optimize-Your-Device/Services.md
+++ b/windows-iot/iot-enterprise/Optimize-Your-Device/Services.md
@@ -2902,7 +2902,7 @@ The following tables offer Microsoft guidance on disabling system services on Wi
 
 | Name | Description |
 |--|--|
-| **Service name** | dot3svc |
+| **Service name** | WLANSVC |
 | **Description** | The WLANSVC service provides the logic required to configure, discover, connect to, and disconnect from a wireless local area network (WLAN) as defined by IEEE 802.11 standards. It also contains the logic to turn your computer into a software access point so that other devices or computers can connect to your computer wirelessly using a WLAN adapter that can support this. Stopping or disabling the WLANSVC service will make all WLAN adapters on your computer inaccessible from the Windows networking UI. It is strongly recommended that you have the WLANSVC service running if your computer has a WLAN adapter. |
 | **Installation** | Always installed |
 | **Startup type** | Manual |


### PR DESCRIPTION
The dot3svc service name was also used for the WLANSVC Service Block.
Change the name to correct the WLANSVC Service.