### PR TITLE
Clarify real-time core indices

### DIFF
--- a/windows-iot/iot-enterprise/Soft-Real-Time/Soft-Real-Time-Device.md
+++ b/windows-iot/iot-enterprise/Soft-Real-Time/Soft-Real-Time-Device.md
@@ -150,6 +150,6 @@ Environments that use Windows Management Instrumentation (WMI) can use the MDM B
 
 >[!TIP]
 >
-> You can use the same script for whatever number of real-time cores you need to have, just replacing the 3 in the second-to-last line with the appropriate number. This will reserve cores starting with the highest core and going downwards. So reserving 3 cores on a 4 core CPU will reserve cores 3, 2, and 1 and leave core 0 for system and non-real-time tasks.
+> You can use the same script for whatever number of real-time cores you need to have, just replacing the 3 in the second-to-last line with the appropriate number. This will reserve cores starting with the highest core and going downwards. So reserving 3 cores on a 4 core CPU will reserve cores 3, 2, and 1 and leave core 0 for system and non-real-time tasks. Please note that there's no guarantee that the real-time cores are going to remain highest, since the real-time core indices will remain fixed if increasing the CPU core count afterwards.
 
 Next: [Develop an Soft Real-Time Application](/windows/iot/iot-enterprise/soft-real-time/soft-real-time-application)


### PR DESCRIPTION
Add note to clarify that the real-time core indices will remain fixed if increasing the CPU core count afterwards. This means that there's no guarantee that the real-time cores will reside on the the last core indices. This is at least observed behavior on Windows 10 IoT enterprise LTSC 2021.

Example to illustrate:
* Create a VM with 4 CPU cores
* Configure 2 real-time cores.
* Observe that the 3rd & 4th core (out of 4) is assigned real-time.
* Increase the CPU core count to 6.
* Observe that the 3rd & 4th core (out of 6) is still assigned real-time, whereas the last two cores behave regularly.

![image](https://user-images.githubusercontent.com/2671400/209096260-78c38a84-b8c2-4e74-a9a7-ee534d7788b9.png)
