### PR TITLE
Simplify SoftRT configuration sample

### DIFF
--- a/windows-iot/iot-enterprise/Soft-Real-Time/Soft-Real-Time-Device.md
+++ b/windows-iot/iot-enterprise/Soft-Real-Time/Soft-Real-Time-Device.md
@@ -129,8 +129,6 @@ Environments that use Windows Management Instrumentation (WMI) can use the MDM B
    $nameSpaceName="root\cimv2\mdm\dmmap"
    $className="MDM_WindowsIoT_SoftRealTimeProperties01"
    $obj = Get-CimInstance -Namespace $namespaceName -ClassName $className
-   Add-Type -AssemblyName System.Web
-   Set-CimInstance -CimInstance $obj
    $obj.SetRTCores = 3
    Set-CimInstance -CimInstance $obj
    ```


### PR DESCRIPTION
The script runs just as fine when testing on Win10 LTSC 2021 without these two lines. I'm furthermore struggling to understand the intent of `Add-Type -AssemblyName System.Web` as well as the apparently redundant `Set-CimInstance -CimInstance $obj` command.