### PR TITLE
Use real service name capitalization

### DIFF
--- a/windows-iot/iot-enterprise/Optimize/Services.md
+++ b/windows-iot/iot-enterprise/Optimize/Services.md
@@ -797,7 +797,7 @@ The following tables offer Microsoft guidance on disabling system services on Wi
 
 | Name | Description |
 |--|--|
-| **Service name** | EapHost |
+| **Service name** | Eaphost |
 | **Description** | The Extensible Authentication Protocol (EAP) service provides network authentication in such scenarios as 802.1x wired and wireless, VPN, and Network Access Protection (NAP). EAP also provides application programming interfaces (APIs) that are used by network access clients, including wireless and VPN clients, during the authentication process. If you disable this service, this computer is prevented from accessing networks that require EAP authentication. |
 | **Installation** | Always installed |
 | **Startup type** | Manual |
@@ -2381,7 +2381,7 @@ The following tables offer Microsoft guidance on disabling system services on Wi
 
 | Name | Description |
 |--|--|
-| **Service name** | Wcncsvc |
+| **Service name** | wcncsvc |
 | **Description** | WCNCSVC hosts the Windows Connect Now Configuration which is Microsoft's Implementation of Wireless Protected Setup (WPS) protocol. This is used to configure Wireless LAN settings for an Access Point (AP) or a Wireless Device. The service is started programmatically as needed. |
 | **Installation** | Always installed |
 | **Startup type** | Automatic |
@@ -2722,7 +2722,7 @@ The following tables offer Microsoft guidance on disabling system services on Wi
 
 | Name | Description |
 |--|--|
-| **Service name** | WLANSVC |
+| **Service name** | WlanSvc |
 | **Description** | The WLANSVC service provides the logic required to configure, discover, connect to, and disconnect from a wireless local area network (WLAN) as defined by IEEE 802.11 standards. It also contains the logic to turn your computer into a software access point so that other devices or computers can connect to your computer wirelessly using a WLAN adapter that can support this. Stopping or disabling the WLANSVC service will make all WLAN adapters on your computer inaccessible from the Windows networking UI. It is strongly recommended that you have the WLANSVC service running if your computer has a WLAN adapter. |
 | **Installation** | Always installed |
 | **Startup type** | Manual |


### PR DESCRIPTION
The capitalization of some service names in the documentation (e.g., EapHost) doesn't match the capitalization of the service names (e.g., Eaphost).  Make them consistent.